### PR TITLE
CTDA9-336: Avoid early dereference of internal IDs.

### DIFF
--- a/src/StreamWrapper/Foxml.php
+++ b/src/StreamWrapper/Foxml.php
@@ -71,9 +71,10 @@ class Foxml extends LocalReadOnlyStream {
 
     try {
       $path = $this->{"{$subtype}Adapter"}->dereference($target_actual);
+      assert(is_string($path), 'Dereferenced path.');
     }
     catch (\Exception $e) {
-      var_dump('asdfasdf');
+      trigger_error('Failed to dereference URI.', E_USER_WARNING);
       return FALSE;
     }
 

--- a/src/Utility/Fedora3/Element/ContentLocation.php
+++ b/src/Utility/Fedora3/Element/ContentLocation.php
@@ -55,7 +55,7 @@ class ContentLocation extends AbstractParser {
         $this->uri = $this->REF;
       }
       elseif ($this->TYPE === 'INTERNAL_ID') {
-        $this->uri = $this->getFoxmlParser()->getDatastreamLowLevelAdapter()->dereference($this->REF);
+        $this->uri = "foxml://datastream/{$this->REF}";
       }
       else {
         throw new \Exception('Unhandled type.');

--- a/src/Utility/Fedora3/LowLevelAdapterInterface.php
+++ b/src/Utility/Fedora3/LowLevelAdapterInterface.php
@@ -15,6 +15,9 @@ interface LowLevelAdapterInterface {
    *
    * @return string
    *   A URI/path to the given resource.
+   *
+   * @throws \Drupal\foxml\Utility\Fedora3\Exceptions\LowLevelDereferenceFailedException
+   *   Should be thrown if we fail to dereference the given ID.
    */
   public function dereference($id) : string;
 


### PR DESCRIPTION
Was actually returning a path instead of the expected URI.