### PR TITLE
D10-9: Safer PHP array destructuring.

### DIFF
--- a/src/StreamWrapper/Foxml.php
+++ b/src/StreamWrapper/Foxml.php
@@ -66,7 +66,13 @@ class Foxml extends LocalReadOnlyStream {
       $uri = $this->uri;
     }
     $target = $this->getTarget($uri);
-    [$subtype, $target_actual] = explode('/', $target, 2);
+    $exploded = explode('/', $target, 2);
+    if (count($exploded) === 1) {
+      // XXX: `foxml://object` and `foxml://datastream` on their own do not
+      // really point anywhere.
+      return FALSE;
+    }
+    [$subtype, $target_actual] = $exploded;
     assert(in_array($subtype, ['object', 'datastream']), 'Valid URI.');
 
     try {


### PR DESCRIPTION
Exposed with the bump to PHP 8, started throwing warnings due to attempting to use things naively.

https://www.php.net/manual/en/language.types.array.php :

> Attempting to access an array key which has not been defined is the same as accessing any other undefined variable: an E_WARNING-level error message (E_NOTICE-level prior to PHP 8.0.0) will be issued, and the result will be null. 

Started popping from [our migration code](https://github.com/discoverygarden/dgi_migrate/blob/75e3c0e1b52f308ac916a48a27bda8378a1f7124/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_foxml_files.yml#L32-L42), as we would:
- have a uri such as `foxml://object/some:pid`
- check that it is _not_ writable
- naively chop to `foxml://object`, to attempt to assert that the parent is also _not_ writable

Thinking: ObjectLowLevel adapters should be expected to avoid providing files which would be deletable. The [`akubra_adapter` implementation does so](https://github.com/discoverygarden/akubra_adapter/blob/38000f45a25cf99c5f34a53cf93193e6fdff88b9/src/Utility/Fedora3/ObjectLowLevelAdapter.php#L40)... adding in some filters so the "archival" adapter should also.