### PR TITLE
DDST-553: Feature/foxml extension bypass

### DIFF
--- a/modules/foxml_file_validation/README.md
+++ b/modules/foxml_file_validation/README.md
@@ -1,0 +1,23 @@
+# FOXML File Validation
+
+## Introduction
+
+In migrations, we provide URIs in the `foxml://` scheme which do not have
+meaningful file extensions, such as:
+
+- `foxml://object/some:pid`; or,
+- `foxml://datastream/some:pid+DSID+DSID.0`
+
+Given these are served from a dedicated endpoint and the usual extension
+validation does not have anything meaningful to work with, this module wraps
+the base `FileExtension` validation such that it is bypassed when the `uri` of
+the underlying file entity has the `foxml://` scheme. File _not_ in the
+`foxml://` scheme should continue to validate extensions unchanged.
+
+## Installation
+
+Enable the (sub)module.
+
+## Configuration
+
+None.

--- a/modules/foxml_file_validation/foxml_file_validation.info.yml
+++ b/modules/foxml_file_validation/foxml_file_validation.info.yml
@@ -1,0 +1,8 @@
+---
+name: 'FOXML File Validation'
+description: "Extended file validation to allow "
+type: module
+package: DGI
+core_version_requirement: ^10.2
+dependencies:
+  - foxml:foxml

--- a/modules/foxml_file_validation/foxml_file_validation.module
+++ b/modules/foxml_file_validation/foxml_file_validation.module
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * General hook implementations.
+ */
+
+use Drupal\foxml_file_validation\Plugin\Validation\Constraint\FoxmlFileExtensionBypassConstraint;
+
+/**
+ * Implements hook_validation_constraint_alter().
+ */
+function foxml_file_validation_validation_constraint_alter(array &$definitions) : void {
+  $definitions['FoxmlFileValidationOriginalFileExtension'] = $definitions['FileExtension'];
+  $definitions['FileExtension']['class'] = FoxmlFileExtensionBypassConstraint::class;
+}

--- a/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraint.php
+++ b/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraint.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\foxml_file_validation\Plugin\Validation\Constraint;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Validation\ConstraintManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Allow extensions for FOXML URIs to be ignored.
+ *
+ * @Constraint(
+ *   id = "FoxmlFileValidationFileExtension",
+ *   label = @Translation("FOXML File Validation, File Extension", context = "Validation"),
+ *   type = "file"
+ * )
+ */
+class FoxmlFileExtensionBypassConstraint extends Constraint implements ContainerFactoryPluginInterface {
+
+  /**
+   * The passed in options, to forward to the wrapped constraint.
+   *
+   * @var mixed|null
+   */
+  protected mixed $options;
+
+  /**
+   * Lazily instantiated wrapped constraint.
+   *
+   * @var \Symfony\Component\Validator\Constraint
+   */
+  protected Constraint $wrapped;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    protected ConstraintManager $constraintManager,
+    mixed $options = NULL,
+    ?array $groups = NULL,
+    mixed $payload = NULL,
+  ) {
+    parent::__construct([], $groups, $payload);
+    $this->options = $options;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      constraintManager: $container->get('validation.constraint'),
+      options: $configuration,
+    );
+  }
+
+  /**
+   * Get the wrapped constraint.
+   *
+   * @return \Symfony\Component\Validator\Constraint
+   *   The wrapped constraint.
+   */
+  public function getWrappedConstraint() : Constraint {
+    if (!isset($this->wrapped)) {
+      $this->wrapped = $this->constraintManager->create('FoxmlFileValidationOriginalFileExtension', $this->options);
+    }
+
+    return $this->wrapped;
+  }
+
+}

--- a/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraint.php
+++ b/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraint.php
@@ -62,11 +62,7 @@ class FoxmlFileExtensionBypassConstraint extends Constraint implements Container
    *   The wrapped constraint.
    */
   public function getWrappedConstraint() : Constraint {
-    if (!isset($this->wrapped)) {
-      $this->wrapped = $this->constraintManager->create('FoxmlFileValidationOriginalFileExtension', $this->options);
-    }
-
-    return $this->wrapped;
+    return $this->wrapped ??= $this->constraintManager->create('FoxmlFileValidationOriginalFileExtension', $this->options);
   }
 
 }

--- a/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraintValidator.php
+++ b/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraintValidator.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\foxml_file_validation\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\Core\Validation\ConstraintValidatorFactory;
+use Drupal\file\Plugin\Validation\Constraint\BaseFileConstraintValidator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Bypasses extension validation for files in the foxml:// scheme.
+ */
+class FoxmlFileExtensionBypassConstraintValidator extends BaseFileConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * Constraint validator factory.
+   *
+   * @var \Drupal\Core\Validation\ConstraintValidatorFactory
+   */
+  protected ConstraintValidatorFactory $constraintValidatorFactory;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    protected StreamWrapperManagerInterface $streamWrapperManager,
+    protected ClassResolverInterface $classResolver,
+  ) {}
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validate(mixed $value, Constraint $constraint) : void {
+    $file = $this->assertValueIsFile($value);
+    if (!$constraint instanceof FoxmlFileExtensionBypassConstraint) {
+      throw new UnexpectedTypeException($constraint, FoxmlFileExtensionBypassConstraint::class);
+    }
+
+    if ($this->streamWrapperManager::getScheme($file->getFileUri()) === 'foxml') {
+      return;
+    }
+
+    $wrapped_constraint = $constraint->getWrappedConstraint();
+    $wrapped_validator = $this->getConstraintValueFactory()->getInstance($wrapped_constraint);
+    $wrapped_validator->initialize($this->context);
+    $wrapped_validator->validate($value, $wrapped_constraint);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) : static {
+    return new static(
+      $container->get('stream_wrapper_manager'),
+      $container->get('class_resolver'),
+    );
+  }
+
+  /**
+   * Lazily instantiate constraint validator factory.
+   *
+   * @return \Drupal\Core\Validation\ConstraintValidatorFactory
+   *   Constraint validator factory service.
+   */
+  protected function getConstraintValueFactory() : ConstraintValidatorFactory {
+    if (!isset($this->constraintValidatorFactory)) {
+      $this->constraintValidatorFactory = new ConstraintValidatorFactory($this->classResolver);
+    }
+
+    return $this->constraintValidatorFactory;
+  }
+
+}

--- a/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraintValidator.php
+++ b/modules/foxml_file_validation/src/Plugin/Validation/Constraint/FoxmlFileExtensionBypassConstraintValidator.php
@@ -67,11 +67,7 @@ class FoxmlFileExtensionBypassConstraintValidator extends BaseFileConstraintVali
    *   Constraint validator factory service.
    */
   protected function getConstraintValueFactory() : ConstraintValidatorFactory {
-    if (!isset($this->constraintValidatorFactory)) {
-      $this->constraintValidatorFactory = new ConstraintValidatorFactory($this->classResolver);
-    }
-
-    return $this->constraintValidatorFactory;
+    return $this->constraintValidatorFactory ??= new ConstraintValidatorFactory($this->classResolver);
   }
 
 }

--- a/src/Plugin/migrate/source/Foxml.php
+++ b/src/Plugin/migrate/source/Foxml.php
@@ -106,7 +106,7 @@ class Foxml extends SourcePluginBase implements ContainerFactoryPluginInterface 
    */
   protected function generatePaths() : \Traversable {
     foreach ($this->generateIds() as $id) {
-      yield $id => $this->objectStorage->dereference($id);
+      yield $id => "foxml://object/{$id}";
     }
   }
 


### PR DESCRIPTION
Contains/builds on #24 

Effectively "decorates" the `FileExtension` constraint to allow `foxml://` URIs to skip extension validation.